### PR TITLE
chore: set preload realms as completed

### DIFF
--- a/text/0008-preload-realm.md
+++ b/text/0008-preload-realm.md
@@ -1,6 +1,8 @@
 - Start Date: 2024-01-11
 - RFC PR: [electron/rfcs#8](https://github.com/electron/rfcs/pull/8)
-- Status: **Active**
+- Electron Commit: [electron/electron@26da3c5](https://github.com/electron/electron/commit/26da3c5d6ed2af2d8ab8d4ab03b35762549b0a2c)
+- Electron Release: v35.0.0  
+- Status: **Completed**
 
 # Preload Realm for Service Workers
 


### PR DESCRIPTION
Setting the Preload Realms RFC as completed now that https://github.com/electron/electron/pull/44411 has been merged.