### PR TITLE
chore: clarify two-week final comment period

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ flowchart TD
 - Eventually, Electron’s API WG will decide if the RFC is a candidate for inclusion in Electron.
   The RFC should be reviewed by at least two WG members, and presented to a quorum of the group at a
   synchronous meeting. If consensus is achieved, then the RFC will be a candidate for acceptance.
-- This will trigger a one-month final comment period for the RFC. Unless any issues come up that
+- This will trigger a two-week final comment period for the RFC. Unless any issues come up that
   the WG consider to block the implementation of the RFC, it will be merged and marked as Active.
 
 ### Working on an Active RFC


### PR DESCRIPTION
Updates a line in the README to reflect https://github.com/electron/rfcs/pull/9